### PR TITLE
Remove addition of default scatter points as causing GLScatter 

### DIFF
--- a/FreeIMU_GUI/FreeIMU_GUI/cal_gui.py
+++ b/FreeIMU_GUI/FreeIMU_GUI/cal_gui.py
@@ -123,11 +123,13 @@ class FreeIMUCal(QMainWindow, Ui_FreeIMUCal):
     mx.setSize(x=1000, y=1000, z=1000)
     self.magn3D.addItem(ax)
     
-    self.acc3D_sp = gl.GLScatterPlotItem()
-    self.acc3D.addItem(self.acc3D_sp)
+    self.acc3D_sp = gl.GLScatterPlotItem()    
+    #removed default scatter add
+    #self.acc3D.addItem(self.acc3D_sp) 
     
     self.magn3D_sp = gl.GLScatterPlotItem()
-    self.magn3D.addItem(self.magn3D_sp)
+    #removed default scatter add
+    #self.magn3D.addItem(self.magn3D_sp)
     
     # axis for the cal 3D graph
     g_a = gl.GLAxisItem()


### PR DESCRIPTION
Error on startup of application: 

'list' object has no attribute 'size'. 

See https://groups.google.com/forum/#!msg/pyqtgraph/Z6h6QHZURyw/dAZVeUDtTUwJ

Removed initial GLScater points. App works without the default items and startup errors are removed
